### PR TITLE
Alternate meta dashboard linking

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -161,7 +161,7 @@ div.meta-view-wrapper {
 
 div.meta-view {
 	display: grid;
-	grid-template-columns: minmax(min-content, 1fr) min-content 1.2fr max-content;
+	grid-template-columns: minmax(min-content, 1fr) 1.2fr max-content;
 	align-self: start;
 	
 	box-shadow: 4px 6px 8px -2px #0003;
@@ -183,6 +183,12 @@ div.meta-header.title a {
 	color: #fff;
 	font-weight: bold;
 }
+a.meta-link {
+	text-decoration: underline;
+}
+a:hover.meta-link {
+	color: #FF7B9C !important;
+}
 a.dash-link {
 	color: #fffc;
 	font-size: 0.8em;
@@ -198,10 +204,10 @@ div.meta-puzzle {
 }
 
 .meta-puzzle.title {
-	grid-column: 1/3;
+	grid-column: 1/2;
 }
 .meta-puzzle.answer {
-	grid-column: 3/5;
+	grid-column: 2/4;
 }
 
 div.menu-header {

--- a/views/metas.hbs
+++ b/views/metas.hbs
@@ -18,11 +18,11 @@
 				{{#each metas}}
 					<div class="meta-view">
 						<div class="meta-header title{{#if complete}} meta-complete{{/if}}">
-							{{name}}
+							<a class="meta-link" href="puzzles?tags=in/{{tagSuffix}}&tags=meta/{{tagSuffix}}{{#if id}}&expanded={{id}}{{/if}}">{{name}}</a>
 						</div>
-						<div class="meta-header dashboard{{#if complete}} meta-complete{{/if}}">
+						<!--<div class="meta-header dashboard{{#if complete}} meta-complete{{/if}}">
 							<a class="dash-link" href="puzzles?tags=in/{{tagSuffix}}&tags=meta/{{tagSuffix}}">[dashboard]</a>
-						</div>
+						</div>-->
 						<div class="meta-header answer{{#if complete}} meta-complete{{/if}}">
 							{{#if answer}}<span class="answer">{{answer}}</span>{{/if}}
 						</div>

--- a/views/metas.hbs
+++ b/views/metas.hbs
@@ -20,9 +20,6 @@
 						<div class="meta-header title{{#if complete}} meta-complete{{/if}}">
 							<a class="meta-link" href="puzzles?tags=in/{{tagSuffix}}&tags=meta/{{tagSuffix}}{{#if id}}&expanded={{id}}{{/if}}">{{name}}</a>
 						</div>
-						<!--<div class="meta-header dashboard{{#if complete}} meta-complete{{/if}}">
-							<a class="dash-link" href="puzzles?tags=in/{{tagSuffix}}&tags=meta/{{tagSuffix}}">[dashboard]</a>
-						</div>-->
 						<div class="meta-header answer{{#if complete}} meta-complete{{/if}}">
 							{{#if answer}}<span class="answer">{{answer}}</span>{{/if}}
 						</div>


### PR DESCRIPTION
Removes the separate [dashboard] link on the meta view, and consolidates it into the puzzle title (or tag suffix if no puzzle listed).
Brings metapuzzle title linking into line with the puzzle linking for the round.
Reinforces that metapuzzle title is clickable.